### PR TITLE
Copilot/fix auth token validation

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -21,6 +21,7 @@ function authenticateToken(req, res, next) {
 		req.user = user;
 		next();
 	} catch (error) {
+		res.clearCookie("auth_token", { httpOnly: true, secure: true, path: "/" });
 		res.redirect(`/login?redirect=${encodeURIComponent(req.originalUrl)}`);
 	}
 }

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -329,6 +329,15 @@ router.post("/register", validateInviteToken, async (req, res) => {
 });
 
 router.get("/login", async (req, res) => {
+	const token = req.cookies.auth_token;
+	if (token) {
+		try {
+			jwt.verify(token, JWT_KEY);
+			return res.redirect("/");
+		} catch {
+			res.clearCookie("auth_token", { httpOnly: true, secure: true, path: "/" });
+		}
+	}
 	res.render("login", req.query);
 });
 


### PR DESCRIPTION
Sometimes when I try to open Lurker I get the following error message in Safari:

`Safari can't open the page "https://lurker.bugeja.com.mt/". The error is: "Load cannot follow more than 20 redirections" (:0)`

This PR solves this issue by breaking the loping redirects from auth.js to index.js and vice versa.