### PR TITLE
Fix HTTPS-only cookie and compact view mobile layout

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,6 +24,7 @@ services:
       LURKER_THEME: ""           # optional; name of a CSS file in src/public without ".css" (default: unset)
 
       # --- Authentication & security ---
+      LURKER_DISABLE_SSL: "false"  # default: "false". Set to "true" to disable the Secure cookie flag (needed for HTTP-only deployments)
       JWT_SECRET_KEY: ""         # auto-generated if unset; set to keep sessions valid across restarts
       REMOTE_HEADER_LOGIN: ""    # default: "false". Set to "true" to enable Remote Header SSO
       ADMIN_GROUP: "admin"       # default: admin (used when REMOTE_HEADER_LOGIN is enabled)

--- a/src/auth.js
+++ b/src/auth.js
@@ -7,7 +7,7 @@ const oidc = require("./oidc");
 const AUTH_TOKEN_MAX_AGE_MS = 5 * 24 * 60 * 60 * 1000;
 const AUTH_TOKEN_COOKIE_OPTIONS = {
 	httpOnly: true,
-	secure: true,
+	secure: process.env.LURKER_DISABLE_SSL !== "true",
 	sameSite: "Strict",
 	path: "/",
 };

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -1006,50 +1006,34 @@ body[data-classic-layout="1"] .domain {
   }
 }
 
-/* Mobile: Stack images below title for better readability */
+/* Mobile: Keep compact row layout with thumbnails */
 @media (max-width: 767px) {
   .post-container.compact {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
+    align-items: flex-start;
+    gap: 0.5rem;
   }
 
   .post-info {
-    flex-direction: column !important;
-    width: 100%;
+    flex: 1;
+    min-width: 0;
   }
 
   .media-preview {
-    order: 1 !important;
-    padding-left: 0 !important;
-    padding-right: 0 !important;
-    margin-left: 0 !important;
-    margin-top: 10px;
-    width: 100%;
-  }
-
-  .media-preview img,
-  .media-preview video {
-    width: 100%;
-    height: auto;
-    max-height: 300px;
-    object-fit: cover;
+    order: -1 !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    flex-shrink: 0;
+    width: auto;
   }
 
   .post-text {
     width: 100%;
   }
 
-  /* Disable classic layout on mobile */
   body[data-classic-layout="1"] .post-container.compact {
-    flex-direction: column;
     padding: 0.3rem;
-  }
-
-  body[data-classic-layout="1"] .media-preview img,
-  body[data-classic-layout="1"] .media-preview video {
-    width: 100%;
-    height: auto;
-    max-height: 300px;
   }
 }
 


### PR DESCRIPTION
Fixes #14 and #15.

## Issue #14 — `secure: true` blocking auth cookie over HTTP

The auth cookie was hardcoded with `secure: true`, silently dropping the cookie in HTTP-only deployments with no error in app logs or browser console.

`LURKER_DISABLE_SSL=true` now sets `secure: false` on the cookie. The default remains `secure: true` (HTTPS required), so existing deployments are unaffected. The new env var is documented in `docker-compose.yaml`.

## Issue #15 — Compact view shows full-width images on mobile

The mobile CSS was overriding `.media-preview img` to `width: 100%` / `height: auto`, making compact view thumbnails expand to full width and look identical to card view. Toggling the high-res thumbnail setting had no visual effect because CSS was overriding the image size regardless of the `src`.

Compact view on mobile now keeps the same row layout with small thumbnails as desktop, consistent with the view's purpose.