### PR TITLE
feat(reddit): add per-user auth headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- Per-user Reddit auth settings in the dashboard for bearer tokens or cookie headers
 - Add /r/popular link to navigation menu (next to /r/all)
 - High-resolution thumbnail support using Reddit preview images (like RES)
   - Uses preview.images API for 640x640+ quality instead of low-res 70x70 thumbnails
@@ -27,5 +28,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Removed hardcoded 100px x 100px dimensions from video preview, now responsive via CSS
 
 ### Technical
+- Database migration: add-reddit-auth-headers-column
 - Database migration: add-high-res-thumbnails-column
-- Modified files: header.pug, postUtils.pug, post.pug, dashboard.pug, db.js, routes/index.js
+- Modified files: header.pug, postUtils.pug, post.pug, dashboard.pug, db.js, routes/index.js, geddit.js, redditAuth.js

--- a/package.json
+++ b/package.json
@@ -1,22 +1,25 @@
 {
-  "name": "scarlet",
-  "module": "index.ts",
-  "type": "module",
-  "devDependencies": {
-    "@types/bun": "latest",
-    "pug-cli": "^1.0.0-alpha6"
-  },
-  "peerDependencies": {
-    "typescript": "^5.6.3"
-  },
-  "dependencies": {
-    "cookie-parser": "^1.4.7",
-    "express": "^5.2.1",
-    "express-rate-limit": "^8.2.1",
-    "he": "^1.2.0",
-    "jsonwebtoken": "^9.0.2",
-    "pug": "^3.0.3",
-    "timeago.js": "^4.0.2",
-    "openid-client": "^6.0.0"
-  }
+	"name": "scarlet",
+	"module": "index.ts",
+	"type": "module",
+	"scripts": {
+		"test": "bun test"
+	},
+	"devDependencies": {
+		"@types/bun": "latest",
+		"pug-cli": "^1.0.0-alpha6"
+	},
+	"peerDependencies": {
+		"typescript": "^5.6.3"
+	},
+	"dependencies": {
+		"cookie-parser": "^1.4.7",
+		"express": "^5.2.1",
+		"express-rate-limit": "^8.2.1",
+		"he": "^1.2.0",
+		"jsonwebtoken": "^9.0.2",
+		"pug": "^3.0.3",
+		"timeago.js": "^4.0.2",
+		"openid-client": "^6.0.0"
+	}
 }

--- a/readme.md
+++ b/readme.md
@@ -136,6 +136,7 @@ each user can customize their experience via the dashboard:
 - **Classic RES-style Layout**: toggle compact desktop layout (thumbnails on left)
 - **High Resolution Thumbnails**: use RES-quality preview images (640x640+) instead of low-res thumbnails (70x70), can be disabled for low bandwidth connections
 - **Theme Preference**: choose between auto (system), light, dark, or RES night mode
+- **Reddit Authentication**: optionally send a per-user Reddit bearer token or cookie header with Reddit JSON requests
 
 **PWA installation**
 
@@ -205,6 +206,7 @@ nix build .#lurker  # build the thing
 - [x] support crossposts
 - [x] PWA support (manifest, icons, meta tags)
 - [x] user preferences system (infinite scroll, themes, layout)
+- [x] per-user Reddit auth header support
 - [x] "Never Ending Reddit" infinite scroll
 - [x] Classic RES-style layout
 - [x] multiple theme support (auto/light/dark/RES)

--- a/src/db.js
+++ b/src/db.js
@@ -120,6 +120,13 @@ runMigration("add-show-nsfw-thumbnails-column", () => {
   `).run();
 });
 
+runMigration("add-reddit-auth-headers-column", () => {
+	db.query(`
+    ALTER TABLE users
+    ADD COLUMN redditAuthHeaders TEXT
+  `).run();
+});
+
 runMigration("add-oidc-support", () => {
 	// Core OIDC fields
 	db.query(`

--- a/src/geddit.js
+++ b/src/geddit.js
@@ -11,8 +11,9 @@ class Geddit {
 			type: "sr,link,user",
 		};
 		this.headers = {
-		    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36",
-		    "Accept": "application/json",
+			"User-Agent":
+				"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36",
+			Accept: "application/json",
 		};
 	}
 
@@ -57,7 +58,35 @@ class Geddit {
 		return url;
 	}
 
-	async getSubmissions(sort = "hot", subreddit = null, options = {}) {
+	getRequestHeaders(requestOptions = {}) {
+		const headers = { ...this.headers };
+		const authHeaders = requestOptions?.authHeaders || {};
+		const authorization =
+			authHeaders.authorization || authHeaders.Authorization;
+		const cookie = authHeaders.cookie || authHeaders.Cookie;
+
+		if (authorization) {
+			headers.Authorization = authorization;
+		}
+		if (cookie) {
+			headers.Cookie = cookie;
+		}
+
+		return headers;
+	}
+
+	getFetchOptions(requestOptions = {}) {
+		return {
+			headers: this.getRequestHeaders(requestOptions),
+		};
+	}
+
+	async getSubmissions(
+		sort = "hot",
+		subreddit = null,
+		options = {},
+		requestOptions = {},
+	) {
 		const params = {
 			limit: 20,
 			include_over_18: true,
@@ -72,10 +101,7 @@ class Geddit {
 			Object.assign({}, params, options),
 		);
 
-		return await fetch(
-			url,
-			{ headers: this.headers },
-		)
+		return await fetch(url, this.getFetchOptions(requestOptions))
 			.then((res) => res.json())
 			.then((json) => json.data)
 			.then((data) => ({
@@ -85,10 +111,10 @@ class Geddit {
 			.catch((err) => null);
 	}
 
-	async getDomainHot(domain, options = this.parameters) {
+	async getDomainHot(domain, options = this.parameters, requestOptions = {}) {
 		return await fetch(
 			`${this.host}/domain/${domain}/hot.json?${new URLSearchParams(options)}`,
-			{ headers: this.headers },
+			this.getFetchOptions(requestOptions),
 		)
 			.then((res) => res.json())
 			.then((json) => json.data)
@@ -99,10 +125,10 @@ class Geddit {
 			.catch((err) => null);
 	}
 
-	async getDomainBest(domain, options = this.parameters) {
+	async getDomainBest(domain, options = this.parameters, requestOptions = {}) {
 		return await fetch(
 			`${this.host}/domain/${domain}/best.json?${new URLSearchParams(options)}`,
-			{ headers: this.headers },
+			this.getFetchOptions(requestOptions),
 		)
 			.then((res) => res.json())
 			.then((json) => json.data)
@@ -113,10 +139,10 @@ class Geddit {
 			.catch((err) => null);
 	}
 
-	async getDomainTop(domain, options = this.parameters) {
+	async getDomainTop(domain, options = this.parameters, requestOptions = {}) {
 		return await fetch(
 			`${this.host}/domain/${domain}/top.json?${new URLSearchParams(options)}`,
-			{ headers: this.headers },
+			this.getFetchOptions(requestOptions),
 		)
 			.then((res) => res.json())
 			.then((json) => json.data)
@@ -127,10 +153,10 @@ class Geddit {
 			.catch((_) => null);
 	}
 
-	async getDomainNew(domain, options = this.parameters) {
+	async getDomainNew(domain, options = this.parameters, requestOptions = {}) {
 		return await fetch(
 			`${this.host}/domain/${domain}/new.json?${new URLSearchParams(options)}`,
-			{ headers: this.headers },
+			this.getFetchOptions(requestOptions),
 		)
 			.then((res) => res.json())
 			.then((json) => json.data)
@@ -141,10 +167,14 @@ class Geddit {
 			.catch((err) => null);
 	}
 
-	async getDomainRising(domain, options = this.parameters) {
+	async getDomainRising(
+		domain,
+		options = this.parameters,
+		requestOptions = {},
+	) {
 		return await fetch(
 			`${this.host}/domain/${domain}/rising.json?${new URLSearchParams(options)}`,
-			{ headers: this.headers },
+			this.getFetchOptions(requestOptions),
 		)
 			.then((res) => res.json())
 			.then((json) => json.data)
@@ -155,10 +185,14 @@ class Geddit {
 			.catch((err) => null);
 	}
 
-	async getDomainControversial(domain, options = this.parameters) {
+	async getDomainControversial(
+		domain,
+		options = this.parameters,
+		requestOptions = {},
+	) {
 		return await fetch(
 			`${this.host}/domain/${domain}/controversial.json?${new URLSearchParams(options)}`,
-			{ headers: this.headers },
+			this.getFetchOptions(requestOptions),
 		)
 			.then((res) => res.json())
 			.then((json) => json.data)
@@ -169,32 +203,35 @@ class Geddit {
 			.catch((err) => null);
 	}
 
-	async getSubreddit(subreddit) {
+	async getSubreddit(subreddit, requestOptions = {}) {
 		const safeSubreddit = this.sanitizeSubredditPath(subreddit);
 		if (!safeSubreddit) return null;
 		const encodedSubreddit = this.encodeSubredditPath(safeSubreddit);
 
-		return await fetch(`${this.host}/r/${encodedSubreddit}/about.json`, {
-			headers: this.headers,
-		})
+		return await fetch(
+			`${this.host}/r/${encodedSubreddit}/about.json`,
+			this.getFetchOptions(requestOptions),
+		)
 			.then((res) => res.json())
 			.then((json) => json.data)
 			.catch((err) => null);
 	}
 
-	async getSubredditRules(subreddit) {
-		return await fetch(`${this.host}/r/${subreddit}/about/rules.json`, {
-			headers: this.headers,
-		})
+	async getSubredditRules(subreddit, requestOptions = {}) {
+		return await fetch(
+			`${this.host}/r/${subreddit}/about/rules.json`,
+			this.getFetchOptions(requestOptions),
+		)
 			.then((res) => res.json())
 			.then((json) => json.data)
 			.catch((err) => null);
 	}
 
-	async getSubredditModerators(subreddit) {
-		return await fetch(`${this.host}/r/${subreddit}/about/moderators.json`, {
-			headers: this.headers,
-		})
+	async getSubredditModerators(subreddit, requestOptions = {}) {
+		return await fetch(
+			`${this.host}/r/${subreddit}/about/moderators.json`,
+			this.getFetchOptions(requestOptions),
+		)
 			.then((res) => res.json())
 			.then((json) => json.data)
 			.then((data) => ({
@@ -203,37 +240,40 @@ class Geddit {
 			.catch((err) => null);
 	}
 
-	async getSubredditWikiPages(subreddit) {
-		return await fetch(`${this.host}/r/${subreddit}/wiki/pages.json`, {
-			headers: this.headers,
-		})
+	async getSubredditWikiPages(subreddit, requestOptions = {}) {
+		return await fetch(
+			`${this.host}/r/${subreddit}/wiki/pages.json`,
+			this.getFetchOptions(requestOptions),
+		)
 			.then((res) => res.json())
 			.then((json) => json.data)
 			.catch((err) => null);
 	}
 
-	async getSubredditWikiPage(subreddit, page) {
-		return await fetch(`${this.host}/r/${subreddit}/wiki/${page}.json`, {
-			headers: this.headers,
-		})
+	async getSubredditWikiPage(subreddit, page, requestOptions = {}) {
+		return await fetch(
+			`${this.host}/r/${subreddit}/wiki/${page}.json`,
+			this.getFetchOptions(requestOptions),
+		)
 			.then((res) => res.json())
 			.then((json) => json.data)
 			.catch((err) => null);
 	}
 
-	async getSubredditWikiPageRevisions(subreddit, page) {
-		return await fetch(`${this.host}/r/${subreddit}/wiki/revisions${page}.json`, {
-			headers: this.headers,
-		})
+	async getSubredditWikiPageRevisions(subreddit, page, requestOptions = {}) {
+		return await fetch(
+			`${this.host}/r/${subreddit}/wiki/revisions${page}.json`,
+			this.getFetchOptions(requestOptions),
+		)
 			.then((res) => res.json())
 			.then((json) => json.data.children)
 			.catch((err) => null);
 	}
 
-	async getPopularSubreddits(options = this.parameters) {
+	async getPopularSubreddits(options = this.parameters, requestOptions = {}) {
 		return await fetch(
 			`${this.host}/subreddits/popular.json?${new URLSearchParams(options)}`,
-			{ headers: this.headers },
+			this.getFetchOptions(requestOptions),
 		)
 			.then((res) => res.json())
 			.then((json) => json.data)
@@ -244,10 +284,10 @@ class Geddit {
 			.catch((err) => null);
 	}
 
-	async getNewSubreddits(options = this.parameters) {
+	async getNewSubreddits(options = this.parameters, requestOptions = {}) {
 		return await fetch(
 			`${this.host}/subreddits/new.json?${new URLSearchParams(options)}`,
-			{ headers: this.headers },
+			this.getFetchOptions(requestOptions),
 		)
 			.then((res) => res.json())
 			.then((json) => json.data)
@@ -258,10 +298,10 @@ class Geddit {
 			.catch((err) => null);
 	}
 
-	async getPremiumSubreddits(options = this.parameters) {
+	async getPremiumSubreddits(options = this.parameters, requestOptions = {}) {
 		return await fetch(
 			`${this.host}/subreddits/premium.json?${new URLSearchParams(options)}`,
-			{ headers: this.headers },
+			this.getFetchOptions(requestOptions),
 		)
 			.then((res) => res.json())
 			.then((json) => json.data)
@@ -272,10 +312,10 @@ class Geddit {
 			.catch((err) => null);
 	}
 
-	async getDefaultSubreddits(options = this.parameters) {
+	async getDefaultSubreddits(options = this.parameters, requestOptions = {}) {
 		return await fetch(
 			`${this.host}/subreddits/default.json?${new URLSearchParams(options)}`,
-			{ headers: this.headers },
+			this.getFetchOptions(requestOptions),
 		)
 			.then((res) => res.json())
 			.then((json) => json.data)
@@ -286,10 +326,10 @@ class Geddit {
 			.catch((err) => null);
 	}
 
-	async getPopularUsers(options = this.parameters) {
+	async getPopularUsers(options = this.parameters, requestOptions = {}) {
 		return await fetch(
 			`${this.host}/users/popular.json?${new URLSearchParams(options)}`,
-			{ headers: this.headers },
+			this.getFetchOptions(requestOptions),
 		)
 			.then((res) => res.json())
 			.then((json) => json.data)
@@ -300,10 +340,10 @@ class Geddit {
 			.catch((err) => null);
 	}
 
-	async getNewUsers(options = this.parameters) {
+	async getNewUsers(options = this.parameters, requestOptions = {}) {
 		return await fetch(
 			`${this.host}/users/new.json?${new URLSearchParams(options)}`,
-			{ headers: this.headers },
+			this.getFetchOptions(requestOptions),
 		)
 			.then((res) => res.json())
 			.then((json) => json.data)
@@ -314,13 +354,13 @@ class Geddit {
 			.catch((err) => null);
 	}
 
-	async searchSubmissions(query, options = {}) {
+	async searchSubmissions(query, options = {}, requestOptions = {}) {
 		options.q = query;
 		options.type = "link";
 
 		return await fetch(
 			`${this.host}/search.json?${new URLSearchParams(options)}`,
-			{ headers: this.headers },
+			this.getFetchOptions(requestOptions),
 		)
 			.then((res) => res.json())
 			.then((json) => json.data)
@@ -331,7 +371,7 @@ class Geddit {
 			.catch((err) => null);
 	}
 
-	async searchSubreddits(query, options = {}) {
+	async searchSubreddits(query, options = {}, requestOptions = {}) {
 		options.q = query;
 
 		const params = {
@@ -341,7 +381,7 @@ class Geddit {
 
 		return await fetch(
 			`${this.host}/subreddits/search.json?${new URLSearchParams(Object.assign(params, options))}`,
-			{ headers: this.headers },
+			this.getFetchOptions(requestOptions),
 		)
 			.then((res) => res.json())
 			.then((json) => json.data)
@@ -352,7 +392,7 @@ class Geddit {
 			.catch((err) => null);
 	}
 
-	async searchUsers(query, options = {}) {
+	async searchUsers(query, options = {}, requestOptions = {}) {
 		options.q = query;
 
 		const params = {
@@ -362,7 +402,7 @@ class Geddit {
 
 		return await fetch(
 			`${this.host}/users/search.json?${new URLSearchParams(Object.assign(params, options))}`,
-			{ headers: this.headers },
+			this.getFetchOptions(requestOptions),
 		)
 			.then((res) => res.json())
 			.then((json) => json.data)
@@ -373,7 +413,7 @@ class Geddit {
 			.catch((err) => null);
 	}
 
-	async searchAll(query, subreddit = null, options = {}) {
+	async searchAll(query, subreddit = null, options = {}, requestOptions = {}) {
 		options.q = query;
 		const subredditStr = subreddit ? `/r/${subreddit}` : "";
 
@@ -385,7 +425,7 @@ class Geddit {
 
 		return await fetch(
 			`${this.host + subredditStr}/search.json?${new URLSearchParams(Object.assign(params, options))}`,
-			{ headers: this.headers },
+			this.getFetchOptions(requestOptions),
 		)
 			.then((res) => res.json())
 			.then((json) =>
@@ -402,22 +442,30 @@ class Geddit {
 			.catch((err) => null);
 	}
 
-	async getSubmission(id) {
-		return await fetch(`${this.host}/by_id/${id}.json`, {
-			headers: this.headers,
-		})
+	async getSubmission(id, requestOptions = {}) {
+		return await fetch(
+			`${this.host}/by_id/${id}.json`,
+			this.getFetchOptions(requestOptions),
+		)
 			.then((res) => res.json())
 			.then((json) => json.data.children[0].data)
 			.catch((err) => null);
 	}
 
-	async getSubmissionComments(id, options = this.parameters) {
+	async getSubmissionComments(
+		id,
+		options = this.parameters,
+		requestOptions = {},
+	) {
 		const safeId = this.sanitizeThingId(id);
 		if (!safeId) return null;
 
 		return await fetch(
-			this.buildRedditUrl(`/comments/${encodeURIComponent(safeId)}.json`, options),
-			{ headers: this.headers },
+			this.buildRedditUrl(
+				`/comments/${encodeURIComponent(safeId)}.json`,
+				options,
+			),
+			this.getFetchOptions(requestOptions),
 		)
 			.then((res) => res.json())
 			.then((json) => ({
@@ -427,7 +475,12 @@ class Geddit {
 			.catch((err) => null);
 	}
 
-	async getSingleCommentThread(parent_id, child_id, options = this.parameters) {
+	async getSingleCommentThread(
+		parent_id,
+		child_id,
+		options = this.parameters,
+		requestOptions = {},
+	) {
 		const safeParentId = this.sanitizeThingId(parent_id);
 		const safeChildId = this.sanitizeThingId(child_id);
 		if (!safeParentId || !safeChildId) return null;
@@ -437,7 +490,7 @@ class Geddit {
 				`/comments/${encodeURIComponent(safeParentId)}/comment/${encodeURIComponent(safeChildId)}.json`,
 				options,
 			),
-			{ headers: this.headers },
+			this.getFetchOptions(requestOptions),
 		)
 			.then((res) => res.json())
 			.then((json) => ({
@@ -447,29 +500,38 @@ class Geddit {
 			.catch((err) => null);
 	}
 
-	async getSubredditComments(subreddit, options = this.parameters) {
+	async getSubredditComments(
+		subreddit,
+		options = this.parameters,
+		requestOptions = {},
+	) {
 		return await fetch(
 			`${this.host}/r/${subreddit}/comments.json?${new URLSearchParams(options)}`,
-			{ headers: this.headers },
+			this.getFetchOptions(requestOptions),
 		)
 			.then((res) => res.json())
 			.then((json) => json.data.children)
 			.catch((err) => null);
 	}
 
-	async getUser(username) {
-		return await fetch(`${this.host}/user/${username}/about.json`, {
-			headers: this.headers,
-		})
+	async getUser(username, requestOptions = {}) {
+		return await fetch(
+			`${this.host}/user/${username}/about.json`,
+			this.getFetchOptions(requestOptions),
+		)
 			.then((res) => res.json())
 			.then((json) => json.data)
 			.catch((err) => null);
 	}
 
-	async getUserOverview(username, options = this.parameters) {
+	async getUserOverview(
+		username,
+		options = this.parameters,
+		requestOptions = {},
+	) {
 		return await fetch(
 			`${this.host}/user/${username}/overview.json?${new URLSearchParams(options)}`,
-			{ headers: this.headers },
+			this.getFetchOptions(requestOptions),
 		)
 			.then((res) => res.json())
 			.then((json) => json.data)
@@ -480,10 +542,14 @@ class Geddit {
 			.catch((err) => null);
 	}
 
-	async getUserComments(username, options = this.parameters) {
+	async getUserComments(
+		username,
+		options = this.parameters,
+		requestOptions = {},
+	) {
 		return await fetch(
 			`${this.host}/user/${username}/comments.json?${new URLSearchParams(options)}`,
-			{ headers: this.headers },
+			this.getFetchOptions(requestOptions),
 		)
 			.then((res) => res.json())
 			.then((json) => json.data)
@@ -494,10 +560,14 @@ class Geddit {
 			.catch((err) => null);
 	}
 
-	async getUserSubmissions(username, options = this.parameters) {
+	async getUserSubmissions(
+		username,
+		options = this.parameters,
+		requestOptions = {},
+	) {
 		return await fetch(
 			`${this.host}/user/${username}/submitted.json?${new URLSearchParams(options)}`,
-			{ headers: this.headers },
+			this.getFetchOptions(requestOptions),
 		)
 			.then((res) => res.json())
 			.then((json) => json.data)
@@ -508,49 +578,62 @@ class Geddit {
 			.catch((err) => null);
 	}
 
-	async getLiveThread(id) {
-		return await fetch(`${this.host}/live/${id}/about.json`, {
-			headers: this.headers,
-		})
+	async getLiveThread(id, requestOptions = {}) {
+		return await fetch(
+			`${this.host}/live/${id}/about.json`,
+			this.getFetchOptions(requestOptions),
+		)
 			.then((res) => res.json())
 			.then((json) => json.data)
 			.catch((err) => null);
 	}
 
-	async getLiveThreadUpdates(id, options = this.parameters) {
+	async getLiveThreadUpdates(
+		id,
+		options = this.parameters,
+		requestOptions = {},
+	) {
 		return await fetch(
 			`${this.host}/live/${id}.json?${new URLSearchParams(options)}`,
-			{ headers: this.headers },
+			this.getFetchOptions(requestOptions),
 		)
 			.then((res) => res.json())
 			.then((json) => json.data.children)
 			.catch((err) => null);
 	}
 
-	async getLiveThreadContributors(id, options = this.parameters) {
+	async getLiveThreadContributors(
+		id,
+		options = this.parameters,
+		requestOptions = {},
+	) {
 		return await fetch(
 			`${this.host}/live/${id}/contributors.json?${new URLSearchParams(options)}`,
-			{ headers: this.headers },
+			this.getFetchOptions(requestOptions),
 		)
 			.then((res) => res.json())
 			.then((json) => json.data.children)
 			.catch((err) => null);
 	}
 
-	async getLiveThreadDiscussions(id, options = this.parameters) {
+	async getLiveThreadDiscussions(
+		id,
+		options = this.parameters,
+		requestOptions = {},
+	) {
 		return await fetch(
 			`${this.host}/live/${id}/discussions.json?${new URLSearchParams(options)}`,
-			{ headers: this.headers },
+			this.getFetchOptions(requestOptions),
 		)
 			.then((res) => res.json())
 			.then((json) => json.data.children)
 			.catch((err) => null);
 	}
 
-	async getLiveThreadsNow(options = this.parameters) {
+	async getLiveThreadsNow(options = this.parameters, requestOptions = {}) {
 		return await fetch(
 			`${this.host}/live/happening_now.json?${new URLSearchParams(options)}`,
-			{ headers: this.headers },
+			this.getFetchOptions(requestOptions),
 		)
 			.then((res) => res.json())
 			.then((json) => json.data.children)

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -822,6 +822,42 @@ form input[type="submit"]:hover {
   flex-flow: row wrap;
 }
 
+.dashboard-fieldset {
+  width: 100%;
+  box-sizing: border-box;
+  margin-top: 20px;
+  padding: 12px;
+  border: 1px solid var(--bg-color-muted);
+  border-radius: 4px;
+}
+
+.dashboard-fieldset legend {
+  padding: 0 4px;
+}
+
+.dashboard-fieldset select {
+  width: 100%;
+  padding: 10px;
+  margin: 10px 0;
+  box-sizing: border-box;
+  border: 1px solid var(--bg-color-muted);
+  border-radius: 4px;
+  background-color: var(--bg-color-muted);
+  color: var(--text-color);
+}
+
+.dashboard-help {
+  width: 100%;
+  margin: 5px 0 10px;
+  color: var(--text-color-muted);
+}
+
+.dashboard-textarea {
+  min-height: 8rem;
+  resize: vertical;
+  font-family: monospace;
+}
+
 .invite-table {
   width: 100%;
   padding: 10px 0;

--- a/src/redditAuth.js
+++ b/src/redditAuth.js
@@ -1,0 +1,280 @@
+const MAX_REDDIT_AUTH_INPUT_LENGTH = 20000;
+const VALID_REDDIT_AUTH_TYPES = new Set([
+	"auto",
+	"bearer",
+	"cookie",
+	"reddit_session",
+]);
+const COOKIE_NAME_PATTERN = /^[A-Za-z0-9._-]+$/;
+const IGNORED_COOKIE_EXPORT_KEYS = new Set([
+	"domain",
+	"expires",
+	"hostonly",
+	"httponly",
+	"name",
+	"path",
+	"priority",
+	"samesite",
+	"secure",
+	"session",
+	"size",
+	"source_port",
+	"source_scheme",
+	"value",
+]);
+
+function stripWrappingQuotes(value) {
+	const trimmed = String(value || "").trim();
+	if (trimmed.length < 2) return trimmed;
+
+	const first = trimmed[0];
+	const last = trimmed[trimmed.length - 1];
+	if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+		return trimmed.slice(1, -1).trim();
+	}
+
+	return trimmed;
+}
+
+function assertHeaderSafe(value) {
+	if (/[\0-\x08\x0A-\x1F\x7F]/.test(value)) {
+		throw new Error("Reddit credential contains invalid header characters");
+	}
+}
+
+function cleanHeaderValue(value) {
+	const cleaned = stripWrappingQuotes(value);
+	assertHeaderSafe(cleaned);
+	return cleaned;
+}
+
+function normalizeAuthorization(value, { allowBare = false } = {}) {
+	const cleaned = cleanHeaderValue(value);
+	const authorizationMatch = cleaned.match(/^Authorization\s*:\s*(.+)$/i);
+	const authValue = authorizationMatch ? authorizationMatch[1].trim() : cleaned;
+	const bearerMatch = authValue.match(/^Bearer\s+(.+)$/i);
+	const token = bearerMatch
+		? bearerMatch[1].trim()
+		: allowBare
+			? authValue
+			: "";
+
+	if (!token) return null;
+	if (/\s/.test(token)) {
+		throw new Error("Bearer token must not contain whitespace");
+	}
+
+	assertHeaderSafe(token);
+	return `Bearer ${token}`;
+}
+
+function parseCookiePair(name, value) {
+	const cookieName = String(name || "").trim();
+	if (!COOKIE_NAME_PATTERN.test(cookieName)) return null;
+	if (IGNORED_COOKIE_EXPORT_KEYS.has(cookieName.toLowerCase())) return null;
+
+	const cookieValue = cleanHeaderValue(value);
+	if (!cookieValue || cookieValue.includes(";")) return null;
+
+	return {
+		name: cookieName,
+		header: `${cookieName}=${cookieValue}`,
+	};
+}
+
+function addCookieHeader(value, cookiePairs) {
+	let raw = String(value || "").trim();
+	const headerMatch = raw.match(/^Cookie\s*:\s*(.+)$/i);
+	if (headerMatch) {
+		raw = headerMatch[1].trim();
+	}
+
+	let added = false;
+	for (const part of raw.split(";")) {
+		const trimmed = part.trim();
+		if (!trimmed || !trimmed.includes("=")) continue;
+
+		const [name, ...valueParts] = trimmed.split("=");
+		const parsed = parseCookiePair(name, valueParts.join("="));
+		if (!parsed) continue;
+
+		cookiePairs.set(parsed.name, parsed.header);
+		added = true;
+	}
+
+	return added;
+}
+
+function addCookieLine(line, cookiePairs) {
+	const trimmed = String(line || "").trim();
+	if (!trimmed) return false;
+	if (trimmed.includes("=")) {
+		return addCookieHeader(trimmed, cookiePairs);
+	}
+
+	const colonMatch = trimmed.match(/^([A-Za-z0-9._-]+)\s*:\s*(.+)$/);
+	if (!colonMatch) return false;
+
+	const parsed = parseCookiePair(colonMatch[1], colonMatch[2]);
+	if (!parsed) return false;
+
+	cookiePairs.set(parsed.name, parsed.header);
+	return true;
+}
+
+function cookieHeaderFromPairs(cookiePairs) {
+	if (cookiePairs.size === 0) return null;
+	return Array.from(cookiePairs.values()).join("; ");
+}
+
+function normalizeCookieInput(input) {
+	const cookiePairs = new Map();
+	const raw = String(input || "").trim();
+	for (const line of raw.split(/\r?\n/)) {
+		addCookieLine(line, cookiePairs);
+	}
+
+	const cookie = cookieHeaderFromPairs(cookiePairs);
+	if (!cookie) {
+		throw new Error("Reddit cookie input must include cookie name/value pairs");
+	}
+
+	return cookie;
+}
+
+function normalizeRedditAuthInput(input, type = "auto") {
+	const raw = String(input || "").trim();
+	if (!raw) return null;
+	if (raw.length > MAX_REDDIT_AUTH_INPUT_LENGTH) {
+		throw new Error("Reddit credential is too long");
+	}
+
+	const authType = VALID_REDDIT_AUTH_TYPES.has(type) ? type : "auto";
+
+	if (authType === "bearer") {
+		return { authorization: normalizeAuthorization(raw, { allowBare: true }) };
+	}
+
+	if (authType === "cookie") {
+		return { cookie: normalizeCookieInput(raw) };
+	}
+
+	if (authType === "reddit_session") {
+		if (raw.includes("=") || /^Cookie\s*:/i.test(raw)) {
+			return { cookie: normalizeCookieInput(raw) };
+		}
+
+		const parsed = parseCookiePair("reddit_session", raw);
+		if (!parsed) {
+			throw new Error("Reddit session cookie value is invalid");
+		}
+		return { cookie: parsed.header };
+	}
+
+	const headers = {};
+	const cookiePairs = new Map();
+
+	for (const line of raw.split(/\r?\n/)) {
+		const trimmed = line.trim();
+		if (!trimmed) continue;
+
+		const authorizationMatch = trimmed.match(/^Authorization\s*:\s*(.+)$/i);
+		if (authorizationMatch) {
+			headers.authorization = normalizeAuthorization(authorizationMatch[1]);
+			continue;
+		}
+
+		const bearer = normalizeAuthorization(trimmed);
+		if (bearer) {
+			headers.authorization = bearer;
+			continue;
+		}
+
+		addCookieLine(trimmed, cookiePairs);
+	}
+
+	const cookie = cookieHeaderFromPairs(cookiePairs);
+	if (cookie) {
+		headers.cookie = cookie;
+	}
+
+	if (!headers.authorization && !headers.cookie) {
+		throw new Error(
+			"Paste a Bearer authorization header, Cookie header, or cookie name/value pairs",
+		);
+	}
+
+	return headers;
+}
+
+function normalizeStoredRedditAuthHeaders(value) {
+	if (!value) return null;
+
+	let parsed = value;
+	if (typeof value === "string") {
+		try {
+			parsed = JSON.parse(value);
+		} catch {
+			return normalizeRedditAuthInput(value);
+		}
+	}
+
+	if (!parsed || typeof parsed !== "object") return null;
+
+	const headers = {};
+	if (parsed.authorization) {
+		headers.authorization = normalizeAuthorization(parsed.authorization);
+	}
+	if (parsed.cookie) {
+		headers.cookie = normalizeCookieInput(parsed.cookie);
+	}
+
+	if (!headers.authorization && !headers.cookie) return null;
+	return headers;
+}
+
+function serializeRedditAuthHeaders(headers) {
+	const normalized = normalizeStoredRedditAuthHeaders(headers);
+	return normalized ? JSON.stringify(normalized) : null;
+}
+
+function getRedditAuthHeaders(value) {
+	return normalizeStoredRedditAuthHeaders(value);
+}
+
+function describeRedditAuthHeaders(value) {
+	const headers = normalizeStoredRedditAuthHeaders(value);
+	if (!headers) return "not configured";
+
+	const parts = [];
+	if (headers.authorization) {
+		parts.push("bearer token");
+	}
+	if (headers.cookie) {
+		const cookieNames = headers.cookie
+			.split(";")
+			.map((part) => part.trim().split("=")[0])
+			.filter(Boolean);
+		parts.push(`cookies (${cookieNames.join(", ")})`);
+	}
+
+	return parts.join(" and ");
+}
+
+function getRedditAuthStatus(value) {
+	const headers = normalizeStoredRedditAuthHeaders(value);
+	return {
+		configured: Boolean(headers),
+		description: headers
+			? describeRedditAuthHeaders(headers)
+			: "not configured",
+	};
+}
+
+module.exports = {
+	describeRedditAuthHeaders,
+	getRedditAuthHeaders,
+	getRedditAuthStatus,
+	normalizeRedditAuthInput,
+	serializeRedditAuthHeaders,
+};

--- a/src/redditAuth.test.js
+++ b/src/redditAuth.test.js
@@ -1,0 +1,82 @@
+const { describe, expect, test } = require("bun:test");
+const {
+	getRedditAuthHeaders,
+	normalizeRedditAuthInput,
+	serializeRedditAuthHeaders,
+} = require("./redditAuth");
+
+describe("normalizeRedditAuthInput", () => {
+	test("normalizes bearer authorization headers", () => {
+		expect(
+			normalizeRedditAuthInput("Authorization: Bearer abc123", "auto"),
+		).toEqual({
+			authorization: "Bearer abc123",
+		});
+
+		expect(normalizeRedditAuthInput("abc123", "bearer")).toEqual({
+			authorization: "Bearer abc123",
+		});
+
+		expect(
+			normalizeRedditAuthInput("Authorization: Bearer abc123", "bearer"),
+		).toEqual({
+			authorization: "Bearer abc123",
+		});
+	});
+
+	test("normalizes cookie headers and devtools-style cookie lines", () => {
+		expect(
+			normalizeRedditAuthInput(
+				"Cookie: reddit_session=abc; token_v2=def",
+				"auto",
+			),
+		).toEqual({
+			cookie: "reddit_session=abc; token_v2=def",
+		});
+
+		expect(
+			normalizeRedditAuthInput(
+				'redesign_out: "true"\nreddit_session: "abc"\ntoken_v2: "def"',
+				"auto",
+			),
+		).toEqual({
+			cookie: "redesign_out=true; reddit_session=abc; token_v2=def",
+		});
+	});
+
+	test("supports a bare reddit_session value when selected", () => {
+		expect(normalizeRedditAuthInput("abc.def", "reddit_session")).toEqual({
+			cookie: "reddit_session=abc.def",
+		});
+	});
+
+	test("round trips serialized stored headers", () => {
+		const serialized = serializeRedditAuthHeaders({
+			authorization: "Bearer abc123",
+			cookie: "reddit_session=abc",
+		});
+
+		expect(getRedditAuthHeaders(serialized)).toEqual({
+			authorization: "Bearer abc123",
+			cookie: "reddit_session=abc",
+		});
+	});
+
+	test("merges stored auth headers into Geddit request headers", async () => {
+		const { Geddit } = await import("./geddit.js");
+		const reddit = new Geddit();
+
+		expect(
+			reddit.getRequestHeaders({
+				authHeaders: {
+					authorization: "Bearer abc123",
+					cookie: "reddit_session=abc",
+				},
+			}),
+		).toMatchObject({
+			Accept: "application/json",
+			Authorization: "Bearer abc123",
+			Cookie: "reddit_session=abc",
+		});
+	});
+});

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -13,6 +13,12 @@ const {
 const { validateInviteToken } = require("../invite");
 const logger = require("../logger");
 const oidc = require("../oidc");
+const {
+	getRedditAuthHeaders,
+	getRedditAuthStatus,
+	normalizeRedditAuthInput,
+	serializeRedditAuthHeaders,
+} = require("../redditAuth");
 
 const router = express.Router();
 const G = new geddit.Geddit();
@@ -221,6 +227,19 @@ const commonRenderOptions = {
 	theme: process.env.LURKER_THEME,
 };
 
+function getRedditRequestOptions(req) {
+	try {
+		const authHeaders = getRedditAuthHeaders(req.user?.redditAuthHeaders);
+		return authHeaders ? { authHeaders } : {};
+	} catch (err) {
+		logger.warn("Ignoring invalid stored Reddit credential", {
+			userId: req.user?.id,
+			error: err?.message || String(err),
+		});
+		return {};
+	}
+}
+
 // GET /
 router.get("/", authenticateToken, async (req, res) => {
 	const subs = db
@@ -246,8 +265,14 @@ router.get("/", authenticateToken, async (req, res) => {
 	const isMulti = true;
 	const isHomePage = true; // Flag to indicate this is the home page
 
-	const postsReq = G.getSubmissions(query.sort, subreddit, query);
-	const aboutReq = G.getSubreddit(subreddit);
+	const redditRequestOptions = getRedditRequestOptions(req);
+	const postsReq = G.getSubmissions(
+		query.sort,
+		subreddit,
+		query,
+		redditRequestOptions,
+	);
+	const aboutReq = G.getSubreddit(subreddit, redditRequestOptions);
 	const [posts, about] = await Promise.all([postsReq, aboutReq]);
 
 	if (query.view === "card" && posts && posts.posts) {
@@ -293,8 +318,14 @@ router.get("/r/:subreddit", authenticateToken, async (req, res) => {
 				.get({ id: req.user.id, subreddit }) !== null;
 	}
 
-	const postsReq = G.getSubmissions(query.sort, subreddit, query);
-	const aboutReq = G.getSubreddit(subreddit);
+	const redditRequestOptions = getRedditRequestOptions(req);
+	const postsReq = G.getSubmissions(
+		query.sort,
+		subreddit,
+		query,
+		redditRequestOptions,
+	);
+	const aboutReq = G.getSubreddit(subreddit, redditRequestOptions);
 	const [posts, about] = await Promise.all([postsReq, aboutReq]);
 
 	if (query.view === "card" && posts && posts.posts) {
@@ -341,7 +372,12 @@ router.get("/api/r/:subreddit/posts", authenticateToken, async (req, res) => {
 		}
 	}
 
-	const posts = await G.getSubmissions(query.sort, subreddit, query);
+	const posts = await G.getSubmissions(
+		query.sort,
+		subreddit,
+		query,
+		getRedditRequestOptions(req),
+	);
 
 	if (query.view === "card" && posts && posts.posts) {
 		posts.posts.forEach(unescape_selftext);
@@ -382,7 +418,11 @@ router.get("/comments/:id", authenticateToken, async (req, res) => {
 	const params = {
 		limit: 50,
 	};
-	const response = await G.getSubmissionComments(id, params);
+	const response = await G.getSubmissionComments(
+		id,
+		params,
+		getRedditRequestOptions(req),
+	);
 	res.render("comments", {
 		data: unescape_submission(response),
 		user: req.user,
@@ -410,6 +450,7 @@ router.get(
 			parent_id,
 			child_id,
 			params,
+			getRedditRequestOptions(req),
 		);
 		const comments = response.comments;
 		comments.forEach(unescape_comment);
@@ -452,7 +493,11 @@ router.get("/sub-search", authenticateToken, async (req, res) => {
 	if (!req.query || !req.query.q) {
 		res.render("sub-search", { user: req.user, ...commonRenderOptions });
 	} else {
-		const { items, after } = await G.searchSubreddits(req.query.q);
+		const { items, after } = await G.searchSubreddits(
+			req.query.q,
+			{},
+			getRedditRequestOptions(req),
+		);
 		const subs = db
 			.query("SELECT subreddit FROM subscriptions WHERE user_id = $id")
 			.all({ id: req.user.id })
@@ -479,7 +524,11 @@ router.get("/post-search", authenticateToken, async (req, res) => {
 	if (!req.query || !req.query.q) {
 		res.render("post-search", { user: req.user, ...commonRenderOptions });
 	} else {
-		const { items, after } = await G.searchSubmissions(req.query.q);
+		const { items, after } = await G.searchSubmissions(
+			req.query.q,
+			{},
+			getRedditRequestOptions(req),
+		);
 		const message =
 			items.length === 0
 				? "no results found"
@@ -504,7 +553,11 @@ router.get("/post-search", authenticateToken, async (req, res) => {
 
 // GET /dashboard
 router.get("/dashboard", authenticateToken, async (req, res) => {
-	logger.debug("Dashboard - req.user from authenticateToken:", req.user);
+	logger.debug("Dashboard - req.user from authenticateToken:", {
+		id: req.user.id,
+		username: req.user.username,
+		isAdmin: req.user.isAdmin,
+	});
 
 	let invites = null;
 	const isAdmin = db
@@ -531,10 +584,21 @@ router.get("/dashboard", authenticateToken, async (req, res) => {
 		showNsfwThumbnails: req.user.showNsfwThumbnails,
 	});
 
+	let redditAuthStatus = { configured: false, description: "not configured" };
+	try {
+		redditAuthStatus = getRedditAuthStatus(req.user.redditAuthHeaders);
+	} catch (err) {
+		logger.warn("Failed to read stored Reddit credential status", {
+			userId: req.user.id,
+			error: err?.message || String(err),
+		});
+	}
+
 	res.render("dashboard", {
 		invites,
 		isAdmin,
 		user: req.user,
+		redditAuthStatus,
 		message: req.query.message,
 		query: req.query,
 		...commonRenderOptions,
@@ -549,12 +613,35 @@ router.post("/update-preferences", authenticateToken, async (req, res) => {
 		themePreference,
 		highResThumbnails,
 		showNsfwThumbnails,
+		redditAuthCredential,
+		redditAuthType,
+		clearRedditAuth,
 	} = req.body;
 	const infiniteScrollValue = infiniteScroll === "1" ? 1 : 0;
 	const useClassicLayoutValue = useClassicLayout === "1" ? 1 : 0;
 	const highResThumbnailsValue = highResThumbnails === "1" ? 1 : 0;
 	const showNsfwThumbnailsValue = showNsfwThumbnails === "1" ? 1 : 0;
 	const themeValue = themePreference || "auto";
+	const hasRedditAuthCredentialInput =
+		typeof redditAuthCredential === "string" &&
+		redditAuthCredential.trim().length > 0;
+	let redditAuthHeadersUpdate;
+
+	try {
+		if (clearRedditAuth === "1") {
+			redditAuthHeadersUpdate = null;
+		} else if (hasRedditAuthCredentialInput) {
+			redditAuthHeadersUpdate = serializeRedditAuthHeaders(
+				normalizeRedditAuthInput(redditAuthCredential, redditAuthType),
+			);
+		}
+	} catch (err) {
+		logger.warn("Rejected invalid Reddit credential input", {
+			userId: req.user.id,
+			error: err?.message || String(err),
+		});
+		return res.redirect("/dashboard?message=Invalid Reddit credential");
+	}
 
 	logger.debug("Received preferences:", {
 		infiniteScroll,
@@ -562,6 +649,8 @@ router.post("/update-preferences", authenticateToken, async (req, res) => {
 		themePreference,
 		highResThumbnails,
 		showNsfwThumbnails,
+		hasRedditAuthCredentialInput,
+		clearRedditAuth: clearRedditAuth === "1",
 		computed: {
 			infiniteScrollValue,
 			useClassicLayoutValue,
@@ -573,28 +662,45 @@ router.post("/update-preferences", authenticateToken, async (req, res) => {
 	});
 
 	try {
+		const redditAuthSql =
+			redditAuthHeadersUpdate !== undefined
+				? ", redditAuthHeaders = $redditAuthHeaders"
+				: "";
+		const updateParams = {
+			infiniteScroll: infiniteScrollValue,
+			useClassicLayout: useClassicLayoutValue,
+			themePreference: themeValue,
+			highResThumbnails: highResThumbnailsValue,
+			showNsfwThumbnails: showNsfwThumbnailsValue,
+			id: req.user.id,
+		};
+
+		if (redditAuthHeadersUpdate !== undefined) {
+			updateParams.redditAuthHeaders = redditAuthHeadersUpdate;
+		}
+
 		const result = db
 			.query(
-				"UPDATE users SET infiniteScroll = $infiniteScroll, useClassicLayout = $useClassicLayout, themePreference = $themePreference, highResThumbnails = $highResThumbnails, showNsfwThumbnails = $showNsfwThumbnails WHERE id = $id",
+				`UPDATE users SET infiniteScroll = $infiniteScroll, useClassicLayout = $useClassicLayout, themePreference = $themePreference, highResThumbnails = $highResThumbnails, showNsfwThumbnails = $showNsfwThumbnails${redditAuthSql} WHERE id = $id`,
 			)
-			.run({
-				infiniteScroll: infiniteScrollValue,
-				useClassicLayout: useClassicLayoutValue,
-				themePreference: themeValue,
-				highResThumbnails: highResThumbnailsValue,
-				showNsfwThumbnails: showNsfwThumbnailsValue,
-				id: req.user.id,
-			});
+			.run(updateParams);
 
 		logger.debug("Update result:", result);
 
 		// Verify the update
 		const updatedUser = db
 			.query(
-				"SELECT infiniteScroll, useClassicLayout, themePreference, highResThumbnails, showNsfwThumbnails FROM users WHERE id = $id",
+				"SELECT infiniteScroll, useClassicLayout, themePreference, highResThumbnails, showNsfwThumbnails, redditAuthHeaders FROM users WHERE id = $id",
 			)
 			.get({ id: req.user.id });
-		logger.debug("User after update:", updatedUser);
+		logger.debug("User after update:", {
+			infiniteScroll: updatedUser?.infiniteScroll,
+			useClassicLayout: updatedUser?.useClassicLayout,
+			themePreference: updatedUser?.themePreference,
+			highResThumbnails: updatedUser?.highResThumbnails,
+			showNsfwThumbnails: updatedUser?.showNsfwThumbnails,
+			redditAuthConfigured: Boolean(updatedUser?.redditAuthHeaders),
+		});
 
 		return res.redirect("/dashboard");
 	} catch (err) {

--- a/src/views/dashboard.pug
+++ b/src/views/dashboard.pug
@@ -46,6 +46,26 @@ html
               option(value="dark" selected=(user.themePreference === 'dark')) Dark
               option(value="res" selected=(user.themePreference === 'res')) RES Night Mode
 
+          fieldset.dashboard-fieldset
+            legend reddit authentication
+            p.dashboard-help
+              | Current: #{redditAuthStatus.description}
+
+            label(for="reddit-auth-type") Credential Type
+            select(id="reddit-auth-type" name="redditAuthType")
+              option(value="auto" selected) Auto-detect
+              option(value="cookie") Cookie header
+              option(value="reddit_session") reddit_session cookie
+              option(value="bearer") Bearer token
+
+            label(for="reddit-auth-credential") Reddit Credential
+            textarea#reddit-auth-credential.dashboard-textarea(name="redditAuthCredential" rows="6" autocomplete="off" autocapitalize="off" spellcheck="false" placeholder="Cookie: reddit_session=...; token_v2=...\nAuthorization: Bearer ...")
+
+            if redditAuthStatus.configured
+              label(for="clear-reddit-auth")
+                input(type="checkbox" id="clear-reddit-auth" name="clearRedditAuth" value="1")
+                | &nbsp;Clear saved Reddit credential
+
           button(type="submit" style="margin-top: 20px;") Save Preferences
 
         if isAdmin


### PR DESCRIPTION
## Summary
- add dashboard controls for per-user Reddit bearer/cookie credentials without echoing saved secrets
- store normalized Reddit auth headers per user and pass them through request-scoped Geddit fetch options
- add focused Bun tests for credential normalization and header merging

## Context
- Addresses #17 by allowing users to configure a Reddit bearer token or authenticated cookie/session header for JSON API requests.

## Tests
- bun test
- bunx @biomejs/biome@1.8.3 check src/redditAuth.js src/redditAuth.test.js src/geddit.js src/routes/index.js src/db.js src/public/styles.css package.json

Target repo: voc0der/lurker (not upstream).