### PR TITLE
fix(reddit): normalize multiline cookie headers

### DIFF
--- a/src/geddit.js
+++ b/src/geddit.js
@@ -58,6 +58,10 @@ class Geddit {
 		return url;
 	}
 
+	isSafeHeaderValue(value) {
+		return typeof value === "string" && !/[\0-\x1F\x7F]/.test(value);
+	}
+
 	getRequestHeaders(requestOptions = {}) {
 		const headers = { ...this.headers };
 		const authHeaders = requestOptions?.authHeaders || {};
@@ -65,10 +69,10 @@ class Geddit {
 			authHeaders.authorization || authHeaders.Authorization;
 		const cookie = authHeaders.cookie || authHeaders.Cookie;
 
-		if (authorization) {
+		if (this.isSafeHeaderValue(authorization)) {
 			headers.Authorization = authorization;
 		}
-		if (cookie) {
+		if (this.isSafeHeaderValue(cookie)) {
 			headers.Cookie = cookie;
 		}
 

--- a/src/redditAuth.js
+++ b/src/redditAuth.js
@@ -105,6 +105,16 @@ function addCookieHeader(value, cookiePairs) {
 	return added;
 }
 
+function collapseCookieHeaderInput(value) {
+	let raw = String(value || "").trim();
+	const headerMatch = raw.match(/^Cookie\s*:\s*([\s\S]+)$/i);
+	if (headerMatch) {
+		raw = headerMatch[1].trim();
+	}
+
+	return raw.replace(/[\r\n]+[ \t]*/g, "");
+}
+
 function addCookieLine(line, cookiePairs) {
 	const trimmed = String(line || "").trim();
 	if (!trimmed) return false;
@@ -130,8 +140,15 @@ function cookieHeaderFromPairs(cookiePairs) {
 function normalizeCookieInput(input) {
 	const cookiePairs = new Map();
 	const raw = String(input || "").trim();
-	for (const line of raw.split(/\r?\n/)) {
-		addCookieLine(line, cookiePairs);
+	const multilineCookieHeader =
+		/[\r\n]/.test(raw) && (/^Cookie\s*:/i.test(raw) || raw.includes(";"));
+
+	if (multilineCookieHeader) {
+		addCookieHeader(collapseCookieHeaderInput(raw), cookiePairs);
+	} else {
+		for (const line of raw.split(/\r?\n/)) {
+			addCookieLine(line, cookiePairs);
+		}
 	}
 
 	const cookie = cookieHeaderFromPairs(cookiePairs);
@@ -169,6 +186,10 @@ function normalizeRedditAuthInput(input, type = "auto") {
 			throw new Error("Reddit session cookie value is invalid");
 		}
 		return { cookie: parsed.header };
+	}
+
+	if (/[\r\n]/.test(raw) && (/^Cookie\s*:/i.test(raw) || raw.includes(";"))) {
+		return { cookie: normalizeCookieInput(raw) };
 	}
 
 	const headers = {};

--- a/src/redditAuth.test.js
+++ b/src/redditAuth.test.js
@@ -44,6 +44,26 @@ describe("normalizeRedditAuthInput", () => {
 		});
 	});
 
+	test("normalizes full cookie headers with hard line breaks", () => {
+		expect(
+			normalizeRedditAuthInput(
+				"Cookie: loid=abc\nZ0FB; csv=2; reddit_session=def",
+				"auto",
+			),
+		).toEqual({
+			cookie: "loid=abcZ0FB; csv=2; reddit_session=def",
+		});
+
+		expect(
+			normalizeRedditAuthInput(
+				"loid=abc\nZ0FB; csv=2; reddit_session=def",
+				"cookie",
+			),
+		).toEqual({
+			cookie: "loid=abcZ0FB; csv=2; reddit_session=def",
+		});
+	});
+
 	test("supports a bare reddit_session value when selected", () => {
 		expect(normalizeRedditAuthInput("abc.def", "reddit_session")).toEqual({
 			cookie: "reddit_session=abc.def",
@@ -78,5 +98,18 @@ describe("normalizeRedditAuthInput", () => {
 			Authorization: "Bearer abc123",
 			Cookie: "reddit_session=abc",
 		});
+	});
+
+	test("does not pass invalid stored cookie headers to fetch", async () => {
+		const { Geddit } = await import("./geddit.js");
+		const reddit = new Geddit();
+		const headers = reddit.getRequestHeaders({
+			authHeaders: {
+				cookie: "reddit_session=abc\nloid=def",
+			},
+		});
+
+		expect(headers.Cookie).toBeUndefined();
+		expect(() => new Headers(headers)).not.toThrow();
 	});
 });


### PR DESCRIPTION
## Summary
- normalize pasted full Cookie headers that include hard line breaks before sending them to Reddit
- add a final Geddit header guard so invalid stored credentials cannot trigger Bun fetch header stack traces
- add regression tests for multiline cookie input and invalid stored cookie header handling

## Context
- Follow-up to #18 after full cookie contents caused `TypeError: Header '26' has invalid value` when opening home.
- Related to #17.

## Tests
- bun test
- bunx @biomejs/biome@1.8.3 check src/redditAuth.js src/redditAuth.test.js src/geddit.js

Target repo: voc0der/lurker (not upstream).