### PR TITLE
chore(dashboard): label reddit auth as burner only

### DIFF
--- a/src/views/dashboard.pug
+++ b/src/views/dashboard.pug
@@ -47,7 +47,7 @@ html
               option(value="res" selected=(user.themePreference === 'res')) RES Night Mode
 
           fieldset.dashboard-fieldset
-            legend reddit authentication
+            legend reddit authentication - burner account only
             p.dashboard-help
               | Current: #{redditAuthStatus.description}
 


### PR DESCRIPTION
## Summary
- update the dashboard Reddit authentication label to warn users to use a burner account only

## Tests
- git diff --check
- bun test

Target repo: voc0der/lurker (not upstream).