### PR TITLE
fix(video): play hosted-video audio via HLS/DASH instead of silent fallback

### DIFF
--- a/src/mixins/head.pug
+++ b/src/mixins/head.pug
@@ -41,3 +41,22 @@ mixin head(title)
     link(rel="preconnect" href="https://rsms.me/")
     link(rel="stylesheet" href="https://rsms.me/inter/inter.css")
     script(src="https://cdn.dashjs.org/latest/dash.all.min.js")
+    script.
+      //- Reddit serves hosted-video audio as a separate stream; the plain
+      //- fallback_url mp4 is video-only. Use the HLS manifest natively
+      //- where supported (Safari/iOS), otherwise hand the DASH manifest
+      //- to dash.js so the audio track actually plays. Deferred until the
+      //- caller decides it's needed (e.g. on first play) so feeds full of
+      //- video posts don't all fetch manifests/segments on mobile data.
+      function initVideoPlayer(video, resume) {
+        if (!video || video.dataset.playerInitialized) return;
+        video.dataset.playerInitialized = "1";
+        var hlsUrl = video.dataset.hlsUrl;
+        var dashUrl = video.dataset.dashUrl;
+        if (hlsUrl && video.canPlayType('application/vnd.apple.mpegurl')) {
+          video.src = hlsUrl;
+          if (resume) video.play();
+        } else if (dashUrl && window.dashjs) {
+          dashjs.MediaPlayer().create().initialize(video, dashUrl, !!resume);
+        }
+      }

--- a/src/mixins/post.pug
+++ b/src/mixins/post.pug
@@ -76,9 +76,11 @@ mixin post(p, currentUrl)
               img(src=p.url loading="lazy")
           else if isPostVideo(p)
             - var decodedVideos = decodePostVideoUrls(p)
-            - var videoSrc = decodedVideos[2] || decodedVideos[1]
-            - var needsDash = !decodedVideos[2] && !!decodedVideos[1]
-            video(data-dashjs-player=needsDash ? "" : null playsinline="" controls="" muted="" preload="metadata" src=videoSrc poster=decodedVideos[4])
+            - var videoSrc = decodedVideos[2] || decodedVideos[1] || decodedVideos[0]
+            video(playsinline="" controls="" muted="" preload="metadata" onplay=`initVideoPlayer(this, true)` src=videoSrc data-hls-url=decodedVideos[0] data-dash-url=decodedVideos[1] poster=decodedVideos[4])
+            if !decodedVideos[2] && (decodedVideos[0] || decodedVideos[1])
+              script.
+                initVideoPlayer(document.currentScript.previousElementSibling);
           else if isPostLink(p)
             a(href=p.url)
               | #{p.domain} ↗

--- a/src/views/comments.pug
+++ b/src/views/comments.pug
@@ -62,9 +62,11 @@ html
               img(src=postMedia.url).post-media
           else if isPostVideo(post)
             - var decodedVideos = decodePostVideoUrls(postMedia)
-            - var videoSrc = decodedVideos[2] || decodedVideos[1]
-            - var needsDash = !decodedVideos[2] && !!decodedVideos[1]
-            video(controls data-dashjs-player=needsDash ? "" : null src=videoSrc).post-media
+            - var videoSrc = decodedVideos[2] || decodedVideos[1] || decodedVideos[0]
+            video(controls onplay=`initVideoPlayer(this, true)` src=videoSrc data-hls-url=decodedVideos[0] data-dash-url=decodedVideos[1] poster=decodedVideos[4]).post-media
+            if !decodedVideos[2] && (decodedVideos[0] || decodedVideos[1])
+              script.
+                initVideoPlayer(document.currentScript.previousElementSibling);
           else if isPostLink(post)
             a(href=post.url)
               | #{post.url}


### PR DESCRIPTION
## Summary
- Fixes #21 — no video had a working audio option. Reddit serves hosted-video audio as a separate stream from the video-only `fallback_url`, so there was never an audio track to unmute.
- Wires up the `dash.js` library that was already being loaded ([head.pug](src/mixins/head.pug)) but never initialized (a `data-dashjs-player` attribute was set with no JS consuming it). Now: native HLS playback on Safari/iOS, or `dash.js` against the DASH manifest elsewhere — both include audio.
- The upgrade happens lazily on first `play`, so feeds full of video posts don't fetch extra manifests/segments on mobile data until the user actually presses play. The autoplay-muted feed thumbnail preview (small silent clip) is untouched, so mobile autoplay stays silent.

## Test plan
- [x] `bun test` passes (7/7)
- [x] Rendered `posts-partial.pug` and `comments.pug` via pug directly with mock Reddit video data (normal case + no-`fallback_url` edge case) and confirmed correct `data-hls-url`/`data-dash-url` attributes and lazy/eager init script placement
- [ ] Manual confirmation in browser with a real Reddit video post (couldn't fully verify live audio in this sandbox — no Reddit OAuth/session available)